### PR TITLE
Add expiration date function

### DIFF
--- a/certs_governance/src/contract.rs
+++ b/certs_governance/src/contract.rs
@@ -60,13 +60,14 @@ impl GovernanceTrait for CertGovernance {
 
     #[cfg(not(tarpaulin_include))]
     fn distribute(
-        _e: Env,
+        e: Env,
         _admin: Address,
         _receiver: Address,
         _wallet_contract_id: Bytes,
         _cid: Bytes,
-        _distribution_date: u64,
+        distribution_date: u64,
     ) {
+        let _expiration_date = expiration_date(&e, distribution_date);
     }
 
     #[cfg(not(tarpaulin_include))]
@@ -117,4 +118,10 @@ impl GovernanceTrait for CertGovernance {
             supply: read_supply(&e),
         }
     }
+}
+
+/// Calculates the expiration date of a distributed Chaincert (using Unix time).
+#[cfg(not(tarpaulin_include))]
+fn expiration_date(e: &Env, distribution_date: u64) -> Option<u64> {
+    read_expiration_time(e).map(|exp_time| distribution_date + exp_time)
 }


### PR DESCRIPTION
## Description

Fixes #7 

Added a function that calculates the certificate expiration date with a distribution date coming from outside the contract and the contract metadata expiration time, the expiration date, will be sent as an attribute to build the Chaincert structure in the wallet contract.
Changed date data types from Bytes and u32 to u64. To use Unix time to represent dates.
More info:
 https://kb.narrative.io/what-is-unix-time
https://www.epochconverter.com/

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings