### PR TITLE
Update `revoke` and `attest` functions

### DIFF
--- a/issuance_contract/src/attest.rs
+++ b/issuance_contract/src/attest.rs
@@ -1,0 +1,61 @@
+//! Module Attest
+//!
+//! Module that groups the functions required to attest a credential.
+use soroban_sdk::{Bytes, Env, Map, String};
+
+use crate::{
+    did_contract::OptionU64,
+    issuance_trait::CredentialStatus,
+    metadata::{read_expiration_time, read_revoked_credentials},
+    recipients::read_recipients,
+    storage_types::{CredentialData, RevokedCredential},
+};
+
+pub fn get_credential_data(e: &Env, recipient: &String) -> Option<CredentialData> {
+    let recipients_map: Map<String, Option<CredentialData>> = read_recipients(&e);
+    if let Some(recipient_data) = recipients_map.get(recipient.clone()) {
+        if let Some(data) = recipient_data.unwrap() {
+            return Some(data.clone());
+        }
+    }
+    None
+}
+
+pub fn get_revoked_credential(e: &Env, recipient: &String) -> Option<RevokedCredential> {
+    let revoked_credentials: Map<String, RevokedCredential> = read_revoked_credentials(&e);
+    if let Some(revoked_credential_result) = revoked_credentials.get(recipient.clone()) {
+        if let Ok(revoked_credential) = revoked_credential_result {
+            return Some(revoked_credential.clone());
+        }
+    }
+    None
+}
+
+pub fn is_valid(data: &CredentialData, credential: &Bytes, signature: &String) -> bool {
+    data.signature == *signature && data.did == *credential
+}
+
+pub fn valid_status(e: &Env) -> CredentialStatus {
+    let expiration_date = read_expiration_time(e);
+    CredentialStatus {
+        status: String::from_slice(e, "valid"),
+        expiration_date,
+        revocation_date: OptionU64::None,
+    }
+}
+pub fn revoked_status(e: &Env, revocation_date: u64) -> CredentialStatus {
+    let expiration_date = read_expiration_time(e);
+    CredentialStatus {
+        status: String::from_slice(e, "revoked"),
+        expiration_date,
+        revocation_date: OptionU64::Some(revocation_date),
+    }
+}
+
+pub fn invalid_status(e: &Env) -> CredentialStatus {
+    CredentialStatus {
+        status: String::from_slice(e, "invalid"),
+        expiration_date: OptionU64::None,
+        revocation_date: OptionU64::None,
+    }
+}

--- a/issuance_contract/src/attest.rs
+++ b/issuance_contract/src/attest.rs
@@ -12,21 +12,19 @@ use crate::{
 };
 
 pub fn get_credential_data(e: &Env, recipient: &String) -> Option<CredentialData> {
-    let recipients_map: Map<String, Option<CredentialData>> = read_recipients(&e);
+    let recipients_map: Map<String, Option<CredentialData>> = read_recipients(e);
     if let Some(recipient_data) = recipients_map.get(recipient.clone()) {
         if let Some(data) = recipient_data.unwrap() {
-            return Some(data.clone());
+            return Some(data);
         }
     }
     None
 }
 
 pub fn get_revoked_credential(e: &Env, recipient: &String) -> Option<RevokedCredential> {
-    let revoked_credentials: Map<String, RevokedCredential> = read_revoked_credentials(&e);
-    if let Some(revoked_credential_result) = revoked_credentials.get(recipient.clone()) {
-        if let Ok(revoked_credential) = revoked_credential_result {
-            return Some(revoked_credential.clone());
-        }
+    let revoked_credentials: Map<String, RevokedCredential> = read_revoked_credentials(e);
+    if let Some(Ok(revoked_credential)) = revoked_credentials.get(recipient.clone()) {
+        return Some(revoked_credential);
     }
     None
 }

--- a/issuance_contract/src/issuance_trait.rs
+++ b/issuance_contract/src/issuance_trait.rs
@@ -32,9 +32,9 @@ pub struct VerifiableCredential {
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct CredentialStatus {
-  pub status: String,
-  pub expiration_date: OptionU64,
-  pub revocation_date: OptionU64,
+    pub status: String,
+    pub expiration_date: OptionU64,
+    pub revocation_date: OptionU64,
 }
 
 pub trait IssuanceTrait {

--- a/issuance_contract/src/issuance_trait.rs
+++ b/issuance_contract/src/issuance_trait.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env, Map, String, Vec};
 
 use crate::{
     did_contract::OptionU64,
-    storage_types::{CredentialData, Info, Organization},
+    storage_types::{CredentialData, Info, Organization, RevokedCredential},
 };
 
 #[contracttype]
@@ -49,7 +49,7 @@ pub trait IssuanceTrait {
     );
 
     /// Revoke a Chaincert from a recipient.
-    fn revoke(e: Env, admin: Address, recipient: String);
+    fn revoke(e: Env, admin: Address, recipient: String, revoked_at: u64);
 
     /// Attest the authenticity and legitimacy of a credential.
     fn attest(
@@ -85,5 +85,5 @@ pub trait IssuanceTrait {
     fn info(e: Env) -> Info;
 
     /// Get all revoked credentials.
-    fn revoked_credentials(e: Env, admin: Address) -> Vec<CredentialData>;
+    fn revoked_credentials(e: Env, admin: Address) -> Vec<RevokedCredential>;
 }

--- a/issuance_contract/src/issuance_trait.rs
+++ b/issuance_contract/src/issuance_trait.rs
@@ -29,6 +29,14 @@ pub struct VerifiableCredential {
     pub issuance_date: u64,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CredentialStatus {
+  pub status: String,
+  pub expiration_date: OptionU64,
+  pub revocation_date: OptionU64,
+}
+
 pub trait IssuanceTrait {
     /// Initialize the contract a list of recipients or with the limit of Chaincerts that can be distributed.
     fn initialize(
@@ -49,7 +57,7 @@ pub trait IssuanceTrait {
     );
 
     /// Revoke a Chaincert from a recipient.
-    fn revoke(e: Env, admin: Address, recipient: String, revoked_at: u64);
+    fn revoke(e: Env, admin: Address, recipient: String, revocation_date: u64);
 
     /// Attest the authenticity and legitimacy of a credential.
     fn attest(
@@ -58,7 +66,7 @@ pub trait IssuanceTrait {
         issuer: Bytes,
         recipient: String,
         signature: String,
-    ) -> bool;
+    ) -> CredentialStatus;
 
     /// Get the Chaincert name.
     fn name(e: Env) -> Bytes;

--- a/issuance_contract/src/lib.rs
+++ b/issuance_contract/src/lib.rs
@@ -6,6 +6,7 @@ mod metadata;
 mod organization;
 mod recipients;
 mod storage_types;
+mod attest;
 mod did_contract {
     soroban_sdk::contractimport!(file = "./did_contract.wasm");
 }

--- a/issuance_contract/src/lib.rs
+++ b/issuance_contract/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+mod attest;
 mod contract;
 mod error;
 mod issuance_trait;
@@ -6,7 +7,6 @@ mod metadata;
 mod organization;
 mod recipients;
 mod storage_types;
-mod attest;
 mod did_contract {
     soroban_sdk::contractimport!(file = "./did_contract.wasm");
 }

--- a/issuance_contract/src/metadata.rs
+++ b/issuance_contract/src/metadata.rs
@@ -3,9 +3,9 @@
 //! Module for obtaining and modifying the metadata fields.
 use crate::{
     did_contract::OptionU64,
-    storage_types::{CredentialData, DataKey},
+    storage_types::{CredentialData, DataKey, RevokedCredential},
 };
-use soroban_sdk::{Bytes, Env, Map, String, Vec};
+use soroban_sdk::{Bytes, Env, Map, String};
 
 pub fn read_file_storage(e: &Env) -> Bytes {
     let key = DataKey::FileStorage;
@@ -37,14 +37,14 @@ pub fn write_revocable(e: &Env, revocable: bool) {
     e.storage().set(&key, &revocable)
 }
 
-pub fn read_revoked_credentials(e: &Env) -> Vec<CredentialData> {
+pub fn read_revoked_credentials(e: &Env) -> Map<String, RevokedCredential> {
     let key = DataKey::RevokedCredentials;
     e.storage().get_unchecked(&key).unwrap()
 }
 
-pub fn write_revoked_credential(e: &Env, credential_list: Vec<CredentialData>) {
+pub fn write_revoked_credentials(e: &Env, revoked_credentials: Map<String, RevokedCredential>) {
     let key = DataKey::RevokedCredentials;
-    e.storage().set(&key, &credential_list)
+    e.storage().set(&key, &revoked_credentials)
 }
 
 pub fn read_expiration_time(e: &Env) -> OptionU64 {

--- a/issuance_contract/src/storage_types.rs
+++ b/issuance_contract/src/storage_types.rs
@@ -22,6 +22,13 @@ pub struct CredentialData {
     pub signature: String,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RevokedCredential {
+    pub credential_data: CredentialData,
+    pub revoked_at: u64,
+}
+
 impl CredentialData {
     pub fn new(
         did: Bytes,
@@ -38,6 +45,15 @@ impl CredentialData {
             credential_title,
             issuance_date,
             signature,
+        }
+    }
+}
+
+impl RevokedCredential {
+    pub fn new(credential_data: CredentialData, revoked_at: u64) -> RevokedCredential {
+        RevokedCredential {
+            credential_data,
+            revoked_at,
         }
     }
 }

--- a/issuance_contract/src/storage_types.rs
+++ b/issuance_contract/src/storage_types.rs
@@ -26,7 +26,7 @@ pub struct CredentialData {
 #[derive(Clone, Debug, PartialEq)]
 pub struct RevokedCredential {
     pub credential_data: CredentialData,
-    pub revoked_at: u64,
+    pub revocation_date: u64,
 }
 
 impl CredentialData {
@@ -50,10 +50,10 @@ impl CredentialData {
 }
 
 impl RevokedCredential {
-    pub fn new(credential_data: CredentialData, revoked_at: u64) -> RevokedCredential {
+    pub fn new(credential_data: CredentialData, revocation_date: u64) -> RevokedCredential {
         RevokedCredential {
             credential_data,
-            revoked_at,
+            revocation_date,
         }
     }
 }


### PR DESCRIPTION
## Description

This PR updates the `revoke` and `attest` functions.

The `revoke` function now receives a new parameter `revocation_date`.
The `attest` function now returns a `CredentialStatus` struct.


Ref #83 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my change