### PR TITLE
Contracts improvements

### DIFF
--- a/vault_contract/src/contract.rs
+++ b/vault_contract/src/contract.rs
@@ -9,7 +9,8 @@ use crate::verifiable_credential::VerifiableCredential;
 
 use crate::vault_trait::VaultTrait;
 use soroban_sdk::{
-    contract, contractimpl, contractmeta, panic_with_error, Address, Env, Map, String, Vec,
+    contract, contractimpl, contractmeta, panic_with_error, Address, Env, Map,
+    String, Vec, IntoVal,
 };
 
 const LEDGERS_THRESHOLD: u32 = 1;
@@ -62,6 +63,15 @@ impl VaultTrait for VaultContract {
     ) {
         validate_did(&e, &recipient_did);
         validate_issuer(&e, &issuer_pk, &recipient_did);
+        issuer_pk.require_auth_for_args(
+            (
+                vc_data.clone(),
+                recipient_did.clone(),
+                issuer_pk.clone(),
+                issuance_contract_address.clone(),
+            )
+                .into_val(&e),
+        );
 
         verifiable_credential::store_vc(
             &e,

--- a/vault_contract/src/contract.rs
+++ b/vault_contract/src/contract.rs
@@ -125,7 +125,7 @@ impl VaultTrait for VaultContract {
         dids.set(
             did.clone(),
             Did {
-                did: did.clone(),
+                did,
                 is_revoked: true,
                 vcs: did_struct.vcs,
             },
@@ -144,7 +144,7 @@ impl VaultTrait for VaultContract {
         dids.set(
             did.clone(),
             Did {
-                did: did.clone(),
+                did,
                 is_revoked: false,
                 vcs: Vec::new(&e),
             },

--- a/vault_contract/src/contract.rs
+++ b/vault_contract/src/contract.rs
@@ -9,8 +9,7 @@ use crate::verifiable_credential::VerifiableCredential;
 
 use crate::vault_trait::VaultTrait;
 use soroban_sdk::{
-    contract, contractimpl, contractmeta, panic_with_error, Address, Env, Map,
-    String, Vec, IntoVal,
+    contract, contractimpl, contractmeta, panic_with_error, Address, Env, IntoVal, Map, String, Vec,
 };
 
 const LEDGERS_THRESHOLD: u32 = 1;

--- a/vc_issuance_contract/src/contract.rs
+++ b/vc_issuance_contract/src/contract.rs
@@ -27,7 +27,7 @@ impl VCIssuanceTrait for VCIssuanceContract {
         if storage::has_admin(&e) {
             panic_with_error!(e, ContractError::AlreadyInitialized);
         }
-        if amount.map_or(false, |a| a > MAX_AMOUNT) {
+        if amount.is_some() && amount.unwrap() > MAX_AMOUNT {
             panic_with_error!(e, ContractError::AmountLimitExceeded);
         }
 

--- a/vc_issuance_contract/src/contract.rs
+++ b/vc_issuance_contract/src/contract.rs
@@ -82,13 +82,7 @@ impl VCIssuanceTrait for VCIssuanceContract {
 
         let mut revocations = storage::read_vcs_revocations(&e);
 
-        revocations.set(
-            vc_id.clone(),
-            Revocation {
-                vc_id: vc_id.clone(),
-                date,
-            },
-        );
+        revocations.set(vc_id.clone(), Revocation { vc_id, date });
 
         storage::write_vcs_revocations(&e, &revocations);
     }

--- a/vc_issuance_contract/src/contract.rs
+++ b/vc_issuance_contract/src/contract.rs
@@ -52,9 +52,10 @@ impl VCIssuanceTrait for VCIssuanceContract {
         validate_admin(&e, &admin);
 
         let vc_id = verifiable_credential::generate_id(&e);
+        let contract_address = e.current_contract_address();
 
         let client = vault_contract::Client::new(&e, &storage_address);
-        client.store_vc(&vc_id, &vc_data, &recipient_did, &admin, &storage_address);
+        client.store_vc(&vc_id, &vc_data, &recipient_did, &admin, &contract_address);
         verifiable_credential::add_vc(&e, &vc_id);
 
         vc_id


### PR DESCRIPTION
## Description
This PR fixes the following:

- **Require auth for all args except vc_id**
  The `issuer_pk.require_auth()` statement can not be called since the `vc_id` is pseudogenerated, it means, it's not deterministic. So the invoker is not able to authorize the invocation with all args. So it's necesary to require auth for all args except `vc_id`.

- **Send current contract address instead of storage address in cross contract call**
  The `storage_address` was being sent instead of the `issuance_contract_address` to the `store_vc` fn of the Vault contract.

- **Simplify amount validation**
  In the `initialize` fn, I avoided using `map_or` to use `is_some` and `unwrap`. Doing validation this way saves resources.

- **Fix clippy warnings**

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my change