### PR TITLE
Prepare release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.19.0 (17.04.2024)
+- Feature: [Set new admin function](https://github.com/kommitters/chaincerts-smart-contracts/issues/192)
+
 ## 0.18.0 (22.03.2024)
 - [Feature: Upgradeable contracts](https://github.com/kommitters/chaincerts-smart-contracts/pull/184)
 - [ci: Harden GitHub Actions](https://github.com/kommitters/chaincerts-smart-contracts/pull/185)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["deployer_contract", "did_contract", "vault_contract", "vc_issuance_contract"]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/kommitters/chaincerts-smart-contracts"


### PR DESCRIPTION
## 0.19.0 (17.04.2024)
- Feature: [Set new admin function](https://github.com/kommitters/chaincerts-smart-contracts/issues/192)