### PR TITLE
Release v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.19.1 (25.04.2024)
+- Add stale issues policy. See [PR #196](https://github.com/kommitters/chaincerts-smart-contracts/pull/196)
+
 ## 0.19.0 (17.04.2024)
 - Feature: [Set new admin function](https://github.com/kommitters/chaincerts-smart-contracts/issues/192)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,15 @@ At this point, you're waiting on us. We like to at least comment on pull request
 business days (typically, one business day). We may suggest some changes, improvements or
 alternatives.
 
+# Stale issues
+
+To ensure that our issue tracker remains organized and relevant, we have implemented a policy for handling Stale issues. Please review the following guidelines:
+
+1. **Marking as Stale**: Issues will be automatically marked as **Stale** after 60 days of inactivity.
+2. **Closing Stale Issues**: After an issue has been marked as Stale, a comment will be posted on the issue indicating that it will be closed if there is no further activity or information provided within a specified period.
+
+Thank you for helping us maintain a clean and efficient issue tracker!
+
 ## Resources
 
 - [How to Contribute to Open Source][oss-how-to]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["deployer_contract", "did_contract", "vault_contract", "vc_issuance_contract"]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/kommitters/chaincerts-smart-contracts"


### PR DESCRIPTION
## 0.19.1 (25.04.2024)
- Add stale issues policy. See [PR #196](https://github.com/kommitters/chaincerts-smart-contracts/pull/196)